### PR TITLE
feat(users): gestão de perfil e exclusão lógica

### DIFF
--- a/apps/api/src/auth/auth.service.ts
+++ b/apps/api/src/auth/auth.service.ts
@@ -11,10 +11,10 @@ import { RegisterDto } from './dto/register.dto';
 import { LoginDto } from './dto/login.dto';
 
 interface GoogleUserData {
-  googleId:    string;
-  email:       string;
+  googleId: string;
+  email: string;
   displayName: string;
-  avatarUrl:   string | null;
+  avatarUrl: string | null;
 }
 
 @Injectable()
@@ -24,14 +24,18 @@ export class AuthService {
     private readonly users: UsersService,
     private readonly jwt: JwtService,
     private readonly config: ConfigService,
-  ) {}
+  ) { }
 
   // ── Registo ───────────────────────────────────────────────────────
   async register(dto: RegisterDto) {
     const existing = await this.users.findByEmail(dto.email);
     if (existing) throw new ConflictException('Já existe uma conta com este email.');
 
-    const passwordHash = await bcrypt.hash(dto.password, 12);
+    const existingUsername = await this.users.findByUsername(dto.username);
+    if (existingUsername) throw new ConflictException('Este username já foi está sendo usado');
+
+    const saltRounds = 12;
+    const passwordHash = await bcrypt.hash(dto.password, saltRounds);
     const user = await this.users.createUser({
       email: dto.email,
       passwordHash,
@@ -65,7 +69,7 @@ export class AuthService {
       if (googleUser.avatarUrl && user.profile && !user.profile.avatarUrl) {
         await this.prisma.profile.update({
           where: { userId: user.id },
-          data:  { avatarUrl: googleUser.avatarUrl },
+          data: { avatarUrl: googleUser.avatarUrl },
         });
         // Recarregar com avatar actualizado
         user = await this.users.findByEmail(googleUser.email);
@@ -82,11 +86,11 @@ export class AuthService {
       const username = await this.generateUniqueUsername(baseUsername);
 
       user = await this.users.createUser({
-        email:       googleUser.email,
-        provider:    'google',
+        email: googleUser.email,
+        provider: 'google',
         username,
         displayName: googleUser.displayName,
-        avatarUrl:   googleUser.avatarUrl ?? undefined,
+        avatarUrl: googleUser.avatarUrl ?? undefined,
         // passwordHash fica null — conta Google não tem password
       });
     }

--- a/apps/api/src/auth/test/auth.http
+++ b/apps/api/src/auth/test/auth.http
@@ -1,0 +1,34 @@
+// cadastro
+POST http://localhost:3001/api/v1/auth/register
+Content-Type: application/json
+
+{
+    "username": "DemoUser",
+    "email": "demo@user.com",
+    "password": "demouser1234_"
+}
+
+###
+// login
+POST http://localhost:3001/api/v1/auth/login
+Content-Type: application/json
+
+{
+    "email": "demo@user.com",
+    "password": "demouser1234_"
+}
+
+###
+// log-out
+POST http://localhost:3001/api/v1/auth/logout
+Authorization: BEARER eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiI1Y2ZiMzhmYy01MmJmLTQ4MmItOTAyOC02MzY0YzEzMjdjMjMiLCJlbWFpbCI6ImRlbW9AdXNlci5jb20iLCJpYXQiOjE3NzU3MzAyNDgsImV4cCI6MTc3NTczMTE0OH0.TDk06fHxfLGjOz2Kp6KHCbPLAr98LqXoIUIhsTp-FmQ
+
+###
+// get me
+@token = yJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiI1Y2ZiMzhmYy01MmJmLTQ4MmItOTAyOC02MzY0YzEzMjdjMjMiLCJlbWFpbCI6ImRlbW9AdXNlci5jb20iLCJpYXQiOjE3NzU3MzA3MzYsImV4cCI6MTc3NTczMTYzNn0.9nbyl2DQzU-YbJMScU2CNVnAPq4VSMY4tbhSjC0ml2g
+GET http://localhost:3001/api/v1/auth/me
+Authorization: Bearer {{token}}
+
+###
+// refresh token
+POST http://localhost:3001/api/v1/auth/refresh

--- a/apps/api/src/users/dto/update-user.dto.ts
+++ b/apps/api/src/users/dto/update-user.dto.ts
@@ -1,0 +1,16 @@
+import { IsOptional, IsString, IsUrl, Length } from "class-validator";
+
+export class UpdateUserDto {
+    @IsOptional()
+    @IsString()
+    @Length(3, 50)
+    displayName?: string
+
+    @IsOptional()
+    @IsUrl()
+    avatarUrl?: string
+
+    @IsOptional()
+    @IsString()
+    bio?: string
+}

--- a/apps/api/src/users/teste/user.http
+++ b/apps/api/src/users/teste/user.http
@@ -1,0 +1,29 @@
+### Variáveis
+@baseUrl = http://localhost:3001/api/v1
+@token = eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiI1Y2ZiMzhmYy01MmJmLTQ4MmItOTAyOC02MzY0YzEzMjdjMjMiLCJlbWFpbCI6ImRlbW9AdXNlci5jb20iLCJpYXQiOjE3NzU4NTA5NzksImV4cCI6MTc3NTg1MTg3OX0.SX9wiQDweZwxzC7T0AdfOXdSyAMC-5KKZmGKQh2w_oI
+
+### 1. Buscar perfil public
+GET {{baseUrl}}/users/Adolfo
+
+### 2. Attivar/desativar modos
+PATCH {{baseUrl}}/users/me/modes
+Authorization: BEARER {{token}}
+Content-Type: application/json
+
+{
+  "modes": ["lazer", "developer"]
+}
+
+### 3. Editar Perfil
+PATCH {{baseUrl}}/users/me
+Authorization: Bearer {{token}}
+Content-Type: application/json
+
+{
+  "displayName": "Adolfo Teste"
+}
+
+
+### 4. Apagar Conta (Soft Delete)
+DELETE {{baseUrl}}/users/me
+Authorization: Bearer {{token}}

--- a/apps/api/src/users/users.controller.ts
+++ b/apps/api/src/users/users.controller.ts
@@ -6,10 +6,11 @@ import { UsersService } from './users.service';
 import { JwtAuthGuard } from '../common/guards/jwt-auth.guard';
 import { CurrentUser } from '../common/decorators/current-user.decorator';
 import { UpdateModesDto } from './dto/update-modes.dto';
+import { UpdateUserDto } from './dto/update-user.dto';
 
 @Controller('users')
 export class UsersController {
-  constructor(private readonly usersService: UsersService) {}
+  constructor(private readonly usersService: UsersService) { }
 
   // ── Perfil público ─────────────────────────────────────────────────
   // TODO (Adolfo v2): implementar getProfile completo com followersCount
@@ -21,6 +22,7 @@ export class UsersController {
     }
     const { user } = profile;
     const { passwordHash, deletedAt, emailVerified, ...safeUser } = user as any;
+    console.log(safeUser)
     return { success: true, data: { ...profile, user: safeUser } };
   }
 
@@ -42,10 +44,13 @@ export class UsersController {
   @UseGuards(JwtAuthGuard)
   async updateProfile(
     @CurrentUser() user: { id: string },
-    @Body() body: any,
+    @Body() dto: UpdateUserDto,
   ) {
-    // Placeholder — Adolfo implementa em v2
-    return { success: true, data: { message: 'Em implementação.' } };
+    const updatedProfile = await this.usersService.updateProfile(user.id, dto)
+    return {
+      success: true,
+      data: updatedProfile
+    }
   }
 
   // ── Apagar conta ───────────────────────────────────────────────────
@@ -55,6 +60,7 @@ export class UsersController {
   @HttpCode(HttpStatus.NO_CONTENT)
   async deleteAccount(@CurrentUser() user: { id: string }) {
     // Placeholder — Adolfo implementa em v2
-    return;
+    await this.usersService.softDelete(user.id)
+    return
   }
 }

--- a/apps/api/src/users/users.service.ts
+++ b/apps/api/src/users/users.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from "@nestjs/common";
 import { PrismaService } from "../prisma/prisma.service";
+import { UpdateUserDto } from "./dto/update-user.dto";
 
 interface CreateUserData {
   email: string;
@@ -12,7 +13,7 @@ interface CreateUserData {
 
 @Injectable()
 export class UsersService {
-  constructor(private readonly prisma: PrismaService) {}
+  constructor(private readonly prisma: PrismaService) { }
 
   async findByEmail(email: string) {
     return this.prisma.user.findUnique({
@@ -58,5 +59,18 @@ export class UsersService {
       where: { userId },
       data: { activeModes: modes },
     });
+  }
+  async updateProfile(userId: string, data: UpdateUserDto) {
+    return this.prisma.profile.update({
+      where: { userId },
+      data,
+    });
+  }
+
+  async softDelete(userId: string) {
+    return this.prisma.user.update({
+      where: { id: userId },
+      data: { deletedAt: new Date() },
+    })
   }
 }

--- a/apps/api/src/users/users.service.ts
+++ b/apps/api/src/users/users.service.ts
@@ -16,24 +16,37 @@ export class UsersService {
   constructor(private readonly prisma: PrismaService) { }
 
   async findByEmail(email: string) {
-    return this.prisma.user.findUnique({
+    const user = await this.prisma.user.findUnique({
       where: { email },
       include: { profile: true },
     });
+
+    if (!user || user.deletedAt) return null
+
+    return user
   }
 
   async findById(id: string) {
-    return this.prisma.user.findUnique({
+    const user = await this.prisma.user.findUnique({
       where: { id },
       include: { profile: true },
     });
+
+    if (!user || user.deletedAt) return null
+
+    return user
+
   }
 
   async findByUsername(username: string) {
-    return this.prisma.profile.findUnique({
+    const profile = await this.prisma.profile.findUnique({
       where: { username },
       include: { user: true },
     });
+
+    if (!profile || profile.user.deletedAt) return null
+
+    return profile
   }
 
   async createUser(data: CreateUserData) {

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,4 +5,6 @@ allowBuilds:
   '@nestjs/core': false
   '@prisma/client': false
   '@prisma/engines': false
+  msgpackr-extract: true
   prisma: false
+  unrs-resolver: true


### PR DESCRIPTION
## Descrição
Este PR finaliza o Módulo 1 da gestão de utilizadores. Foi implementada a lógica de busca pública, edição de dados do perfil e a funcionalidade de Soft Delete para garantir a privacidade dos dados.

##  O que foi feito?
- **GET /users/:username**: Criada rota para visualização de perfis públicos (ignora utilizadores deletados).
- **PATCH /users/me**: Implementada atualização de `displayName`, `bio` e `avatarUrl` via DTO.
- **PATCH /users/me/modes**: Lógica para ativar/desativar modos de perfil.
- **DELETE /users/me**: Implementação de Soft Delete usando o campo `deletedAt`.

## Como testar?
1. Realizar Login para obter o `accessToken`.
2. Testar a edição de perfil enviando um PATCH para `/users/me`.
3. Executar o DELETE em `/users/me` e verificar se o `deletedAt` foi preenchido na DB.
4. Tentar buscar o perfil deletado via `/users/:username` e validar o retorno 404.

## 🔗 
Closes #75  